### PR TITLE
Build zbirka workflow

### DIFF
--- a/.github/workflows/build-zbirka.yml
+++ b/.github/workflows/build-zbirka.yml
@@ -43,11 +43,11 @@ jobs:
       - name: Build zbirka
         run: pipenv run fab build
 
-      # Uploads slides as an artifact (Available for download in job Summary)
+      # Uploads HTML and PDF as an artifact (Available for download in job Summary)
       - name: Make artifacts available for download
         uses: actions/upload-artifact@v2
         with:
-          name: Slides
+          name: zbirka
           path: |
             ./_build/html/
             ./_build/latex/zbirka.pdf

--- a/.github/workflows/build-zbirka.yml
+++ b/.github/workflows/build-zbirka.yml
@@ -20,10 +20,10 @@ jobs:
 
       - name: Install Latex dependencies
         run: |
-          apt install -y texlive-latex-base
-          apt install -y texlive-fonts-recommended
-          apt install -y texlive-fonts-extra
-          apt install -y texlive-latex-extra
+          sudo apt-get install -y texlive-latex-base
+          sudo apt-get install -y texlive-fonts-recommended
+          sudo apt-get install -y texlive-fonts-extra
+          sudo apt-get install -y texlive-latex-extra
 
       - name: Setup Python 3
         uses: actions/setup-python@v2

--- a/.github/workflows/build-zbirka.yml
+++ b/.github/workflows/build-zbirka.yml
@@ -35,7 +35,7 @@ jobs:
 
       # Uploads slides as an artifact (Available for download in job Summary)
       - name: Make artifacts available for download
-      - uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2
         with:
           name: Slides
           path: |

--- a/.github/workflows/build-zbirka.yml
+++ b/.github/workflows/build-zbirka.yml
@@ -18,6 +18,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install Latex dependencies
+        run: |
+          apt install -y texlive-latex-base
+          apt install -y texlive-fonts-recommended
+          apt install -y texlive-fonts-extra
+          apt install -y texlive-latex-extra
+
       - name: Setup Python 3
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/build-zbirka.yml
+++ b/.github/workflows/build-zbirka.yml
@@ -1,0 +1,44 @@
+
+name: Build Zbirka
+
+on:
+  # Triggers the workflow on push or pull request events for all branches
+  push:
+    branches: '**'
+  pull_request:
+    branches: '**'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Python 3
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+          architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install pipenv
+        run: pip install --user pipenv
+
+      - name: Build zbirka
+        run: pipenv run fab build
+
+      # Uploads slides as an artifact (Available for download in job Summary)
+      - name: Make artifacts available for download
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Slides
+          path: |
+            ./_build/html/
+            ./_build/latex/zbirka.pdf
+

--- a/.github/workflows/build-zbirka.yml
+++ b/.github/workflows/build-zbirka.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install pipenv
         run: pip install --user pipenv
 
+      - name: Install dependencies in virtualenv by using pipenv
+        run: pipenv install
+
       - name: Build zbirka
         run: pipenv run fab build
 


### PR DESCRIPTION
I had some Github Action workflow file for similar use case, so I decided to slightly modify it for building pjisp-zbirka-zadataka.
build-zbirka.yml does the following:

* Runs on every push/pull request, or can be triggered on demand
* Installs Latex and Python dependecies
* Builds "zbirka" from .rst files
* Makes HTML and PDF available for download as one Zip archive after successful build

The whole process takes about 4 minutes (for Open Source projects, GitHub minutes are free and unlimited, right? :) ).
Please take a look at this [build report](https://github.com/RadeKornjaca/pjisp-zbirka-zadataka/actions/runs/753863429) for more details.
Purpose of this is to make available to all of our colleagues to check their assignments before making a PR.
Also, it would run again on PR, which should be of help for reviewers. :)